### PR TITLE
refactor: optimize for slow connections

### DIFF
--- a/scripts/htmlTemplate.js
+++ b/scripts/htmlTemplate.js
@@ -1,4 +1,4 @@
-module.exports = () => `
+module.exports = (content = '', scripts = '') => `
   <!DOCTYPE html>
   <html>
   <head>
@@ -11,11 +11,10 @@ module.exports = () => `
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">${content}</div>
 
     <script src="https://api.dmcdn.net/all.js"></script>
-    <script src="/wpruntime.js"></script>
-    <script src="/client.js"></script>
+    ${scripts}
   </body>
   </html>
 `

--- a/scripts/prebuildHtml.js
+++ b/scripts/prebuildHtml.js
@@ -1,7 +1,15 @@
 const fs = require('fs')
 
 const htmlTemplate = require('./htmlTemplate')
+const getAppContent = require('../dist/bundle-server')
 
-const html = htmlTemplate()
+const wpRuntimeScript = fs.readFileSync(`${__dirname}/../dist/wpruntime.js`)
+const criticalScript = fs.readFileSync(`${__dirname}/../dist/critical.js`)
+
+const html = htmlTemplate(getAppContent.default(), `
+   <script type="text/javascript">${wpRuntimeScript}</script>
+   <script type="text/javascript">${criticalScript}</script>
+`)
 fs.writeFileSync(`${__dirname}/../dist/index.html`, html, 'utf-8')
+
 

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -17,8 +17,6 @@ export default
 class App extends Component {
   state = { mounted: false }
   componentDidMount() {
-    playerService.load(window.location.pathname.replace(/^\//, ''))
-
     this.setState({
       mounted: true,
     })

--- a/src/App/PlayerHolder/PlayerHolder.js
+++ b/src/App/PlayerHolder/PlayerHolder.js
@@ -5,9 +5,6 @@ import styles from './PlayerHolder.scss'
 
 export default
 class PlayerHolder extends Component {
-  componentDidMount() {
-    playerService.init(this.playerElt)
-  }
 
   shouldComponentUpdate() {
     return false

--- a/src/critical.js
+++ b/src/critical.js
@@ -1,0 +1,6 @@
+import playerService from 'src/playerService'
+
+playerService.init(document.getElementById('player-holder'))
+playerService.load(window.location.pathname.replace(/^\//, ''))
+
+import(/* webpackChunkName: "reactapp" */ './client')

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+
+import App from './App/App'
+
+export default () => {
+  return renderToString(<App />)
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,48 +29,87 @@ const resolve = {
   },
 }
 
-module.exports = {
-  mode: process.env.NODE_ENV === 'development' ? 'development' : 'production',
-  entry: {
-    'client': './src/client.js',
-  },
-  target: 'web',
-  output: {
-    path: `${__dirname}/dist`,
-    filename: '[name].js',
-    publicPath: '/',
+module.exports = [
+  {
+    mode: process.env.NODE_ENV === 'development' ? 'development' : 'production',
+    entry: {
+      'critical': './src/critical.js',
+    },
+    target: 'web',
+    output: {
+      path: `${__dirname}/dist`,
+      filename: '[name].js',
+      publicPath: '/',
+    },
+    module: {
+      rules: [
+        {
+          test: /.*\.js$/,
+          use: 'babel-loader'
+        },
+        {
+          test: /.*\.scss/,
+          use: [
+            ExtractCssChunksPlugin.loader,
+            {
+              loader: 'css-loader',
+              query: { modules: true },
+            },
+            'sass-loader',
+          ]
+        }
+      ]
+    },
+
+    plugins: [
+      new ExtractCssChunksPlugin({
+        filename: 'styles.css',
+        chunkFilename: 'styles.css',
+      }),
+      new webpack.EnvironmentPlugin({
+        IS_BROWSER: true,
+      })
+    ],
+
+    optimization,
+    resolve,
   },
 
-  module: {
-    rules: [
-      {
-        test: /.*\.js$/,
-        use: 'babel-loader'
-      },
-      {
-        test: /.*\.scss/,
-        use: [
-          ExtractCssChunksPlugin.loader,
-          {
-            loader: 'css-loader',
-            query: { modules: true },
-          },
-          'sass-loader',
-        ]
-      }
-    ]
-  },
+  {
+    mode: process.env.NODE_ENV === 'development' ? 'development' : 'production',
+    entry: './src/server.js',
+    target: 'node',
+    output: {
+      path: `${__dirname}/dist`,
+      filename: 'bundle-server.js',
+      libraryTarget: 'commonjs2',
+    },
 
-  plugins: [
-    new ExtractCssChunksPlugin({
-      filename: 'styles.css',
-      chunkFilename: 'styles.css',
-    }),
-    new webpack.EnvironmentPlugin({
-      IS_BROWSER: true,
-    })
-  ],
+    module: {
+      rules: [
+        {
+          test: /.*\.js$/,
+          use: 'babel-loader'
+        },
+        {
+          test: /.*\.scss/,
+          use: [
+            {
+              loader: 'css-loader/locals',
+              query: { modules: true },
+            },
+            'sass-loader',
+          ]
+        }
+      ]
+    },
 
-  optimization,
-  resolve,
-}
+    plugins: [
+      new webpack.EnvironmentPlugin({
+        IS_BROWSER: false,
+      })
+    ],
+
+    resolve,
+  }
+]


### PR DESCRIPTION
This branch reorchestrates the way the application boots.

Here's what it does:

## Server Side Rendering at build time

The commit does several changes to render the `<App />` component at build time thanks to `react-dom/server`'s `renderToString` function.

To do this, we add a webpack configuration for backend code execution in webpack.config.js (see changes in that file), having as entry the `server.js` file. This file does exports a function that returns the result of `renderToString(<App />)` - that is to say a string containing a partial render of the `<App />` component (with loaders instead of real content when needed).

The `prebuildHtml.js` uses the result of that build (`bundle-server.js`) to get that rendered string and insert it in the HTML template.

## Add a tiny critical script that loads the video

The commit also changes the webpack build for front-end's entry, pointing it to the `src/critical.js` module. This module initializes the player, loads a video, then calls a dynamic import (`import('./client')`) to load the React application.

By calling a dynamic import, the resulting code is split into two bundles: `critical.js` and `reactapp.js`. Since the critical script is really small, the commit actually embeds that script in the index.html to gain even more time (this prevents having to load a file).